### PR TITLE
DENG: Handle OpenSSL.SSL.WantReadError

### DIFF
--- a/pytaboola/client.py
+++ b/pytaboola/client.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import requests
+import tenacity
 
 from pytaboola.errors import Unauthorized
 from pytaboola.utils import parse_response
@@ -90,6 +91,12 @@ class TaboolaClient:
     def token_details(self):
         return self.execute('GET', 'backstage/api/1.0/token-details/')
 
+    @tenacity.retry(
+        stop=tenacity.stop_after_attempt(6),
+        wait=tenacity.wait_exponential(multiplier=1, exp_base=2),
+        retry=tenacity.retry_if_exception_type((ReadTimeout, ConnectTimeout)),
+        before_sleep=tenacity.before_sleep_log(logger, logging.INFO),
+    )
     def execute(self, method, uri, query_params=None,
                 allow_refresh=True, raw=False, authenticated=True,
                 **payload):

--- a/pytaboola/client.py
+++ b/pytaboola/client.py
@@ -16,19 +16,13 @@ class TaboolaClient:
     base_url = 'https://backstage.taboola.com'
 
     def __init__(self, client_id, client_secret=None,
-                 access_token=None, refresh_token=None,
-                 timeout=None):
-        """
-        timeout (in seconds) will be passed to requests.request().
-        If timeout is not set, then default to None. Which will wait forever.
-        """
+                 access_token=None, refresh_token=None):
 
         assert client_secret or access_token, "Must provide either the client secret or an access token"
         self.access_token = access_token
         self.refresh_token = refresh_token
         self.client_id = client_id
         self.client_secret = client_secret
-        self.timeout = timeout
 
         if not self.access_token:
             self.refresh()
@@ -104,8 +98,7 @@ class TaboolaClient:
                 data = payload if raw else json.dumps(payload)
             result = requests.request(method, url, data=data,
                                       params=query_params,
-                                      headers=headers,
-                                      timeout=self.timeout)
+                                      headers=headers)
             return parse_response(result)
         except Unauthorized:
             if not allow_refresh:

--- a/pytaboola/client.py
+++ b/pytaboola/client.py
@@ -2,6 +2,7 @@ import json
 import logging
 import requests
 import tenacity
+from requests.exceptions import ReadTimeout, ConnectTimeout
 
 from pytaboola.errors import Unauthorized
 from pytaboola.utils import parse_response

--- a/pytaboola/client.py
+++ b/pytaboola/client.py
@@ -16,13 +16,19 @@ class TaboolaClient:
     base_url = 'https://backstage.taboola.com'
 
     def __init__(self, client_id, client_secret=None,
-                 access_token=None, refresh_token=None):
+                 access_token=None, refresh_token=None,
+                 timeout=None):
+        """
+        timeout (in seconds) will be passed to requests.request().
+        If timeout is not set, then default to None. Which will wait forever.
+        """
 
         assert client_secret or access_token, "Must provide either the client secret or an access token"
         self.access_token = access_token
         self.refresh_token = refresh_token
         self.client_id = client_id
         self.client_secret = client_secret
+        self.timeout = timeout
 
         if not self.access_token:
             self.refresh()
@@ -98,7 +104,8 @@ class TaboolaClient:
                 data = payload if raw else json.dumps(payload)
             result = requests.request(method, url, data=data,
                                       params=query_params,
-                                      headers=headers)
+                                      headers=headers,
+                                      timeout=self.timeout)
             return parse_response(result)
         except Unauthorized:
             if not allow_refresh:

--- a/pytaboola/client.py
+++ b/pytaboola/client.py
@@ -2,7 +2,7 @@ import json
 import logging
 import requests
 import tenacity
-from requests.exceptions import ReadTimeout, ConnectTimeout
+from requests.exceptions import ReadTimeout, ConnectTimeout, ConnectionError 
 
 from pytaboola.errors import Unauthorized
 from pytaboola.utils import parse_response
@@ -95,7 +95,7 @@ class TaboolaClient:
     @tenacity.retry(
         stop=tenacity.stop_after_attempt(6),
         wait=tenacity.wait_exponential(multiplier=1, exp_base=2),
-        retry=tenacity.retry_if_exception_type((ReadTimeout, ConnectTimeout)),
+        retry=tenacity.retry_if_exception_type((ReadTimeout, ConnectTimeout, ConnectionError)),
         before_sleep=tenacity.before_sleep_log(logger, logging.INFO),
     )
     def execute(self, method, uri, query_params=None,

--- a/pytaboola/services/service.py
+++ b/pytaboola/services/service.py
@@ -4,7 +4,7 @@ from pytaboola.services.base import CrudService, BaseService
 logger = logging.getLogger(__name__)
 
 
-class AdvertiserService(services.base.BaseService):
+class AdvertiserService(BaseService):
     '''
     Only return advertisers under a container to handle
     situations where account permissions overlap or

--- a/pytaboola/services/service.py
+++ b/pytaboola/services/service.py
@@ -34,8 +34,8 @@ class CampaignItemService(CrudService):
 
     def build_uri(self, endpoint=None):
         base_endpoint = '{}/{}/campaigns/{}/items/'.format(self.endpoint,
-                                                           self.campaign_id,
-                                                           self.account_id)
+                                                           self.account_id,
+                                                           self.campaign_id)
         if not endpoint:
             return base_endpoint
         while endpoint.startswith('/'):

--- a/pytaboola/services/service.py
+++ b/pytaboola/services/service.py
@@ -4,6 +4,24 @@ from pytaboola.services.base import CrudService, BaseService
 logger = logging.getLogger(__name__)
 
 
+class AdvertiserService(services.base.BaseService):
+    '''
+    Only return advertisers under a container to handle
+    situations where account permissions overlap or
+    are shared across multiple users.
+    '''
+
+    def __init__(self, client, container_id):
+        super().__init__(client)
+        self.container_id = container_id
+
+    def build_uri(self, endpoint=None):
+        return '{}/{}/advertisers'.format(self.endpoint, self.container_id)
+
+    def list(self):
+        return self.execute('GET', self.build_uri())
+
+
 class AccountService(BaseService):
     endpoint = '{}/{}'.format(BaseService.endpoint,
                               'users/current/allowed-accounts/')


### PR DESCRIPTION
# Summary

1. Taboola API started to show `OpenSSL.SSL.WantReadError`. We add `requests.exceptions.ConnectionError` to retry.

# Deployment Instructions

1. merge
2. add new release
3. change requirements.txt in OpenMail repo.